### PR TITLE
somewhat fixed. check notes

### DIFF
--- a/frontend/src/pages/EventPage.jsx
+++ b/frontend/src/pages/EventPage.jsx
@@ -9,13 +9,11 @@ export default function EventPage({ added, setAdded }) {
   const { id } = useParams();
   const [aEvent, setAEvent] = useState(null);
   const [loading, setLoading] = useState(false);
-  // const [added, setAdded] = useState(false)
+  // const [added, setAdded] = useState(false);
   const apiKey = import.meta.env.VITE_API_KEY;
 
   useEffect(() => {
     fetchEvent();
-    handleAddToMyEvents();
-    handleRemoveEvent();
   }, [id]);
 
   const fetchEvent = async () => {


### PR DESCRIPTION
Each time i clicked a card it kept auto adding it to my events. This was due to handleadd and handleremove being inside the useeffect. 

That is fixed and the event is no longer auto added, but there is still an issue with how the event is being tracked once its added to my events.

When I add a event to myevents on the EventPage I can see it on the myevents page. Now if i remove the event at the myevents page, and then go back to the EventPage, the button still shows "remove from events", even though it has already been removed. then when clicking the button, it returns an error since it cant be removed (bc it doesn't exist). After refreshing the page a few times the button will reset back to "add to events"

Need to figure out how to get that to update in real time when a event is removed from myevents page. maybe using outletcontext or something.